### PR TITLE
Add ShakaCode gem favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 48" fill="none">
+  <defs>
+    <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="b">
+      <stop stop-color="#F32B05" offset="0%" />
+      <stop stop-color="#B00012" offset="100%" />
+    </linearGradient>
+    <linearGradient x1="50%" y1="24.608%" x2="50%" y2="72.622%" id="c">
+      <stop stop-color="#FF6956" offset=".792%" />
+      <stop stop-color="#FF6956" stop-opacity=".01" offset="96.579%" />
+    </linearGradient>
+    <path
+      d="M11.207 0h41.586a2 2 0 011.77 1.069l8.702 16.534a2 2 0 01-.453 2.437L33.317 45.848a2 2 0 01-2.634 0L1.188 20.04a2 2 0 01-.453-2.437L9.438 1.069A2 2 0 0111.207 0z"
+      id="a"
+    />
+  </defs>
+  <mask id="d" fill="#fff">
+    <use href="#a" />
+  </mask>
+  <use fill="url(#b)" href="#a" />
+  <path
+    d="M7 33c22.118-2.144 33.57-6.578 34.354-13.303 1.178-10.088-17.4-1.454-20.927-1 9.658-7.17 22.018-11.721 37.08-13.652H66V47H7V33z"
+    fill="url(#c)"
+    mask="url(#d)"
+  />
+</svg>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -16,6 +16,7 @@ const fullTitle = title === "Home" ? siteTitle : `${title} | ${siteTitle}`;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{fullTitle}</title>
     {description && <meta name="description" content={description} />}
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site)} />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Add SVG favicon using the ShakaCode red gem icon extracted from the logo
- Add `<link rel="icon">` tag to the Base layout

## Test plan
- [ ] Verify favicon appears in browser tab at ai.shakacode.com after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static asset + single head tag change; low likelihood of regressions beyond favicon caching or browser support quirks.
> 
> **Overview**
> Adds a new `public/favicon.svg` (ShakaCode gem icon) and updates `Base.astro` to include a `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />` in the document head so the site serves an SVG favicon.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9610f5c979abced027ea1e8318a0bd12e8ee4795. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added website favicon for improved visual branding in browser tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->